### PR TITLE
Update quickstart_demo.ipynb

### DIFF
--- a/quickstart_demo.ipynb
+++ b/quickstart_demo.ipynb
@@ -320,7 +320,7 @@
     "sarc.detect_z_bands_fast_movie()\n",
     "\n",
     "# analysis of sarcomere length and orientation (only single frame)\n",
-    "sarc.analyze_sarcomere_vectors(frames=0, radius=0.25)"
+    "sarc.analyze_sarcomere_vectors(frames=0, median_filter_radius=0.25)"
    ],
    "id": "a5c65bfa1bc81c44",
    "outputs": [],


### PR DESCRIPTION
fixes #1

this PR simply fixes the "TypeError: unexpected keyword argument" in the quickstart_demo.ipynb file